### PR TITLE
Add on-demand PR preview deployments to Cloudflare Workers

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,58 @@
+# Tears down the Cloudflare Workers preview created by deploy-preview.yml when
+# a pull request is closed (whether merged or not).
+#
+# `wrangler delete` is wrapped with `continue-on-error: true` because the worker
+# may not exist if `/preview` was never invoked on this PR.
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: preview-pr-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    env:
+      WORKER_NAME: docs-point-pr-${{ github.event.number }}
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Delete preview worker
+        id: delete
+        continue-on-error: true
+        run: npx wrangler delete --name "$WORKER_NAME"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Find existing preview comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- docs-point-preview -->'
+
+      - name: Update preview comment
+        if: steps.find-comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- docs-point-preview -->
+            ### :wastebasket: docs-point preview removed
+
+            The preview worker `${{ env.WORKER_NAME }}` has been deleted because this pull request was closed.

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,130 @@
+# Deploys a Cloudflare Workers preview of the docs-point site for a pull request
+# when an authorized user comments `/preview` on the PR.
+#
+# Notes:
+# - Triggered by `issue_comment` so we can scope deploys to explicit human intent.
+# - Skips PRs from forks: even though `issue_comment` workflows have access to
+#   secrets, building untrusted fork code with our credentials is unsafe.
+# - Deploys without `--env`, which means wrangler uses the top-level `[assets]`
+#   block in `wrangler.toml` and ignores the production/staging routes.
+name: Deploy PR Preview
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: preview-pr-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/preview') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    env:
+      WORKER_NAME: docs-point-pr-${{ github.event.issue.number }}
+
+    steps:
+      - name: React to trigger comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: rocket
+
+      - name: Resolve PR head
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json headRefOid,headRefName,headRepositoryOwner,isCrossRepository \
+            > pr.json
+          echo "sha=$(jq -r .headRefOid pr.json)" >> "$GITHUB_OUTPUT"
+          echo "ref=$(jq -r .headRefName pr.json)" >> "$GITHUB_OUTPUT"
+          echo "fork=$(jq -r .isCrossRepository pr.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Reject fork PRs
+        if: steps.pr.outputs.fork == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            :no_entry: Preview deployments are not available for pull requests from forks.
+            Please open the PR from a branch in this repository.
+
+      - name: Stop on fork PR
+        if: steps.pr.outputs.fork == 'true'
+        run: exit 1
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers
+        id: deploy
+        run: |
+          npx wrangler deploy --name "$WORKER_NAME" | tee deploy.log
+          # Wrangler prints the deployed URL on a line like
+          #   "  https://docs-point-pr-123.<subdomain>.workers.dev"
+          url=$(grep -Eo 'https://[a-zA-Z0-9.-]+\.workers\.dev' deploy.log | head -n1)
+          if [ -z "$url" ]; then
+            echo "::error::Could not determine deployed worker URL from wrangler output."
+            exit 1
+          fi
+          echo "url=${url}/point/" >> "$GITHUB_OUTPUT"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Find existing preview comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- docs-point-preview -->'
+
+      - name: Post or update preview comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.issue.number }}
+          edit-mode: replace
+          body: |
+            <!-- docs-point-preview -->
+            ### :rocket: docs-point preview deployed
+
+            | | |
+            |---|---|
+            | **Preview URL** | ${{ steps.deploy.outputs.url }} |
+            | **Worker** | `${{ env.WORKER_NAME }}` |
+            | **Commit** | `${{ steps.pr.outputs.sha }}` |
+            | **Branch** | `${{ steps.pr.outputs.ref }}` |
+            | **Updated** | ${{ github.event.comment.created_at }} |
+
+            Comment `/preview` again to redeploy the latest commit.
+            The preview is automatically removed when this PR is closed.


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows that provide on-demand per-PR preview deployments of the docs site to Cloudflare Workers.

## What's added

- **`.github/workflows/deploy-preview.yml`** — Triggered when an authorized user (`OWNER` / `MEMBER` / `COLLABORATOR`) comments `/preview` on a PR. Builds the docs and deploys a per-PR Cloudflare Worker named `docs-point-pr-{N}`. Posts a sticky comment with the preview URL (parsed from `wrangler deploy` output).
- **`.github/workflows/cleanup-preview.yml`** — Runs on `pull_request: closed` (both merge and close-without-merge), deletes the worker, and updates the sticky comment.

## What's not changed

- `wrangler.toml` — unchanged. Previews use the top-level `[assets]` block via `wrangler deploy --name`, bypassing the production/staging route configs.
- `package.json` — unchanged. `wrangler` is invoked directly via `npx` in CI.

## Safety

- Fork PRs are rejected (checking out and building untrusted fork code with our Cloudflare credentials is unsafe).
- Author-association gate prevents drive-by commenters from triggering deploys.
- `concurrency` group cancels superseded runs so repeated `/preview` comments don't pile up.

## How to test

1. Open a small docs PR against `staging`.
2. Comment `/preview` on the PR.
3. Confirm the workflow runs, the sticky comment appears with a `*.workers.dev/point/` URL, and the URL renders the docs correctly.
4. Push another commit; re-comment `/preview`; confirm the sticky comment is updated (not duplicated) at the new SHA.
5. Close the PR (without merging); verify the cleanup workflow runs and the worker is removed (Cloudflare dashboard).
6. Open another PR, deploy a preview, then merge — confirm cleanup also runs on merge.
7. As a non-collaborator (test account), comment `/preview` — confirm the workflow is skipped.